### PR TITLE
Update RCS.cfg

### DIFF
--- a/GameData/StockalikeHypergols/Patches/RCS.cfg
+++ b/GameData/StockalikeHypergols/Patches/RCS.cfg
@@ -11,7 +11,7 @@
 	@IspVacHyper *= #$IspMult$
 	@IspASHyper *= #$IspMult$
 	
-	@MODULE[ModuleB9PartSwitch:HAS[#switcherDescription[RCS?Mode]]
+	@MODULE[ModuleB9PartSwitch]:HAS[#switcherDescription[RCS?Mode]]
 	{
 	 	SUBTYPE
 		{
@@ -44,14 +44,15 @@
 					}
 				}
 			}
-	  }
-   		 SUBTYPE
+		}
+   		
+		SUBTYPE
 		{
 			name = Hypergolic
 			title = Hypergolic
 			primaryColor = PurpleBrown
 			secondaryColor = SalmonPink
-			descriptionDetail = #HydrogenPeroxide<br><b>Isp:</b> $/IspASLHTP$ / $/IspVacHTP$ s.
+			descriptionDetail = #Hypergolic<br><b>Isp:</b> $/IspASLHTP$ / $/IspVacHTP$ s.
 			MODULE
 			{
 				IDENTIFIER
@@ -81,8 +82,10 @@
 					}
 				}
 			}
-	  }
+		}
+	}
 }
+
 @PART[*]:HAS[@MODULE[ModuleRCSFX],!MODULE[B9PartSwitch:HAS[#switcherDescription[RCS?Mode]]]]:NEEDS[B9PartSwitch]:FOR[zzzStockalikeHypergols]
 {
 	IspVac = #$MODULE[ModuleRCSFX]/atmosphereCurve/key,0[1, ]$ // get vac Isp number
@@ -216,5 +219,6 @@
 				}
 			}
    
-  }
+		}
+	}
 }


### PR DESCRIPTION
Was missing some closing brackets.  Didn't test other than bare install with B9 part switch to see that it would load in the game and provide some parts missing brackets.  I would recommend using :HAS[#moduleID[RCS]] as an alternative search for MM.  You may ultimately may want to use a localization string with switcherDescription and that could break the patch for non-english translations (thinking big here :-)...).